### PR TITLE
Fix parsing problem

### DIFF
--- a/Sources/Veil/Veil.swift
+++ b/Sources/Veil/Veil.swift
@@ -193,7 +193,9 @@ public class Veil {
 
         let (matches, output) = token.maskCharacter(inputChar)
         let (_, pureInput) = token.read(inputChar)
-
+        
+        guard !output.isEmpty else { return (output, pureInput) }
+        
         let result = process(
                     input: matches ? String(inputRemaining) : input, pattern: tokensRemaining,
                     config: config,

--- a/Tests/VeilTests/VeilTests.swift
+++ b/Tests/VeilTests/VeilTests.swift
@@ -29,6 +29,19 @@ final class VeilTests: XCTestCase {
         XCTAssert(unmaskedInput == "12")
     }
 
+    func test_cannot_process_digit_pattern() {
+        let mask = Veil(pattern: "##.##.####")
+        let (maskedInput, unmaskedInput) = mask.process(input: "sometext", exhaustive: false)
+        XCTAssertEqual(maskedInput, "")
+        XCTAssertEqual(unmaskedInput, "")
+    }
+    
+    func test_can_process_some_digit_pattern() {
+        let mask = Veil(pattern: "##.##.####")
+        let (maskedInput, unmaskedInput) = mask.process(input: "12andtext", exhaustive: false)
+        XCTAssertEqual(maskedInput, "12.")
+        XCTAssertEqual(unmaskedInput, "12")
+    }
 
     static var allTests = [
         ("testExample", test_can_mask_input),


### PR DESCRIPTION
Hi! Thanks for your solution!
I've faced a problem with some cases and want to share it with you. 
Let's see the example:
My date mask: `"##.##.####"` and I paste the string `"sometext"`. The result is `".."` It looks strange.
Or if I have mask `"##.##.####"` and I past the string `"12andtext"`. The result is `"12.."`
One more example: `"(###)"` and I paste the string `"sometext"`. The result is `"()"`
I fixed this case and added some tests.
I expect that in the first case I get empty string and in the second case I get `"12."`

I suggest to stop parsing if current value is empty. 

Before the fix
<img width="1116" alt="Screenshot 2022-01-11 at 12 25 33" src="https://user-images.githubusercontent.com/22646611/148917687-6b421740-8e98-4a8f-9271-2d3b4a002d23.png">

